### PR TITLE
import BleakClient for mac

### DIFF
--- a/src/meshcore_cli/meshcore_cli.py
+++ b/src/meshcore_cli/meshcore_cli.py
@@ -19,6 +19,7 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.shortcuts import radiolist_dialog
+from bleak import BleakClient
 
 from meshcore import MeshCore, EventType, logger
 


### PR DESCRIPTION
fix running meshcore-cli on mac.  See accompanying pull request for meshcore_py.

not tested on anything else but a mac.  Anything else needed?