### PR TITLE
Nix: Bump meshcore dependency to 2.1.18

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,9 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs =
-    inputs:
+  outputs = inputs:
     inputs.flake-utils.lib.eachDefaultSystem (
-      system:
-      let
+      system: let
         pkgs = inputs.nixpkgs.legacyPackages.${system};
 
         lib = pkgs.lib;
@@ -17,15 +15,15 @@
 
         meshcore = python3Packages.buildPythonPackage rec {
           pname = "meshcore";
-          version = "2.1.9";
+          version = "2.1.18";
           pyproject = true;
 
           src = python3Packages.fetchPypi {
             inherit pname version;
-            sha256 = "sha256-FhTOuVHhpYvmITgxfhXys8AJhRfYnMwCJ3fWJhMf53w=";
+            sha256 = "sha256-hLflGBHG1z0b31oLh5KgXQbrYeBgYtY07fjgULw68tA=";
           };
 
-          build-system = [ python3Packages.hatchling ];
+          build-system = [python3Packages.hatchling];
 
           dependencies = [
             python3Packages.bleak
@@ -33,13 +31,12 @@
             python3Packages.pyserial-asyncio
           ];
 
-          pythonImportsCheck = [ "meshcore" ];
+          pythonImportsCheck = ["meshcore"];
         };
 
         pyproject = lib.importTOML ./pyproject.toml;
         version = pyproject.project.version;
-      in
-      {
+      in {
         packages.meshcore-cli = python3Packages.buildPythonPackage {
           pname = "meshcore-cli";
           inherit version;


### PR DESCRIPTION
cli requires python meshcore 2.1.18, bumping pinned dependency.

Fixes:
```
       last 25 log lines:
       > Sourcing python-imports-check-hook.sh
       > Using pythonImportsCheckPhase
       > Sourcing python-namespaces-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/750phfip2sq4sp6388c23jn6qb9dxyc3-v6j9g36jh9kf5akj0pv8awnh5fsfg9r7-source
       > source root is v6j9g36jh9kf5akj0pv8awnh5fsfg9r7-source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "v6j9g36jh9kf5akj0pv8awnh5fsfg9r7-source/src/meshcore_cli/meshcore_cli.py"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       > * Building wheel...
       > Successfully built meshcore_cli-1.1.39-py3-none-any.whl
       > Finished creating a wheel...
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for meshcore_cli-1.1.39-py3-none-any.whl
       >   - meshcore>=2.1.17 not satisfied by version 2.1.9
       For full logs, run 'nix log /nix/store/080ybf8i8m640s2p4fw240sywvmyc9l2-python3.13-meshcore-cli-1.1.39.drv'.
       ```