### PR TITLE
Update: MeshCore version in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,14 +17,12 @@
 
         meshcore = python3Packages.buildPythonPackage rec {
           pname = "meshcore";
-          version = "2.2.1";
+          version = "2.2.2";
           pyproject = true;
 
-          src = pkgs.fetchFromGitHub {
-            owner = "meshcore-dev";
-            repo = "meshcore_py";
-            rev = "v${version}";
-            sha256 = "sha256-Qjwi7JrSyk5wWM63OdFykB850+hquWDD9p4fZFfbI70=";
+          src = python3Packages.fetchPypi {
+            inherit pname version;
+            sha256 = "sha256-vn/vF4avMDwDLL0EMVrrMWkZrZ1GTiUxGyTBOtKvG1I=";
           };
 
           build-system = [ python3Packages.hatchling ];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
-dependencies = [ "meshcore >= 2.2.1",
+dependencies = [ "meshcore >= 2.2.2",
 				 "bleak >= 0.22, <2.0", 
 				 "prompt_toolkit >= 3.0.50", 
 				 "requests >= 2.28.0", 


### PR DESCRIPTION
Updated the MeshCore version in the flake. I am not sure why, but on https://pypi.org/project/meshcore/ the latest release is 2.2.2, while on https://github.com/meshcore-dev/meshcore_py/releases it is 2.2.1.

I would suggest using GitHub as the source of truth, which is implemented in this commit. I also set the requirement in `pyproject.toml` back to 2.2.1.