### PR TITLE
Update Nix flake for 2.2.3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,12 +17,12 @@
 
         meshcore = python3Packages.buildPythonPackage rec {
           pname = "meshcore";
-          version = "2.2.2";
+          version = "2.2.3";
           pyproject = true;
 
           src = python3Packages.fetchPypi {
             inherit pname version;
-            sha256 = "sha256-vn/vF4avMDwDLL0EMVrrMWkZrZ1GTiUxGyTBOtKvG1I=";
+            sha256 = "sha256-lmMflAlrNnfsc10J3CBxor9ftHK10bWyGTbjASJv82s=";
           };
 
           build-system = [ python3Packages.hatchling ];


### PR DESCRIPTION
Similar to #19, the dependency on meshcore 2.2.3 in 2a62d80 has broken the Nix flake. 

This change updates the meshcore dependency in flake.nix to match the version in pyproject.toml to fix the issue.

Without this fix, this is what currently happens when the user tries to `nix run` this repo:

```bash
$ nix run github:meshcore-dev/meshcore-cli#meshcore-cli
error: Cannot build '/nix/store/y9g7732vkq2w5gf7ibwp5dm5ndpr3jvp-python3.13-meshcore-cli-1.3.11.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/23xzv0migbizh0mc03x8frfx8r7fhlrb-python3.13-meshcore-cli-1.3.11
         /nix/store/mrkpb5lricarnb5dj4bdjl46h15yr4na-python3.13-meshcore-cli-1.3.11-dist
       Last 25 log lines:
       > Sourcing python-imports-check-hook.sh
       > Using pythonImportsCheckPhase
       > Sourcing python-namespaces-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/ffjsxm7hs5w52aisxapd2w3c4h9vzfzr-37xsl7nrgmvsq6sfk7maybxvrpfqi3yz-source
       > source root is 37xsl7nrgmvsq6sfk7maybxvrpfqi3yz-source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "37xsl7nrgmvsq6sfk7maybxvrpfqi3yz-source/src/meshcore_cli/meshcore_cli.py"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       > * Building wheel...
       > Successfully built meshcore_cli-1.3.11-py3-none-any.whl
       > Finished creating a wheel...
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for meshcore_cli-1.3.11-py3-none-any.whl
       >   - meshcore>=2.2.3 not satisfied by version 2.2.2
       For full logs, run:
         nix log /nix/store/y9g7732vkq2w5gf7ibwp5dm5ndpr3jvp-python3.13-meshcore-cli-1.3.11.drv
```