### PR TITLE
make channel scopes configurable

### DIFF
--- a/src/meshcore_cli/meshcore_cli.py
+++ b/src/meshcore_cli/meshcore_cli.py
@@ -41,6 +41,16 @@ MCCLI_CONFIG_DIR = os.path.expanduser("~/.config/meshcore/")
 MCCLI_ADDRESS = MCCLI_CONFIG_DIR + "default_address"
 MCCLI_HISTORY_FILE = MCCLI_CONFIG_DIR + "history"
 MCCLI_INIT_SCRIPT = MCCLI_CONFIG_DIR + "init"
+MCCLI_SCOPES_FILE = MCCLI_CONFIG_DIR + "scopes"
+
+# Per channel scope overrides, one "<channel name> <scope>" per line.
+SCOPES = {}
+if os.path.exists(MCCLI_SCOPES_FILE) :
+    with open(MCCLI_SCOPES_FILE, "r") as lines:
+        for line in lines:
+            line = line.strip()
+            channel, scope = line.split()
+            SCOPES[channel] = scope
 
 PAYLOAD_TYPENAMES = ["REQ", "RESPONSE", "TEXT_MSG", "ACK", "ADVERT", "GRP_TXT", "GRP_DATA", "ANON_REQ", "PATH", "TRACE", "MULTIPART", "CONTROL"]
 ROUTE_TYPENAMES = ["TC_FLOOD", "FLOOD", "DIRECT", "TC_DIRECT"]
@@ -1236,6 +1246,8 @@ async def process_line(mc, line, contact=None, scope="*", prev_contact=None, pre
         if '%' in dest and scope!=None :
             dest_scope = dest.split("%")[-1]
             dest = dest[:-len(dest_scope)-1]
+        elif dest in SCOPES.keys():
+            dest_scope = SCOPES[dest]
         nc = await get_contact_from_arg(mc, dest)
         if nc is None:
             if dest == "public" :


### PR DESCRIPTION
This is a quick hack to add per channel scope configuration and I'm probably doing it wrong.

Currently this only works when `default_scope` is not set.

Configuration file is straightforward and must be edited manually:
```
$ cat .config/meshcore/scopes
Public *
#estonia ee
#tartu ee
#test ee
```

I wish to have similar behavior as with mobile/web app where I can override default scope per channel, even if default scope is set (in experimental settings).

Happy to hear feedback from maintainer(s) and even more happier if anyone else implements this feature as they see fit. Thanks!